### PR TITLE
RepositoryのWartremoverの警告を抑制

### DIFF
--- a/app/domain/qiita/QiitaUserInitialRepository.scala
+++ b/app/domain/qiita/QiitaUserInitialRepository.scala
@@ -2,6 +2,7 @@ package domain.qiita
 
 import scalikejdbc.{AutoSession, DBSession}
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
 trait QiitaUserInitialRepository {
   def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit
 

--- a/app/domain/qiita/user/QiitaUserRepository.scala
+++ b/app/domain/qiita/user/QiitaUserRepository.scala
@@ -2,6 +2,7 @@ package domain.qiita.user
 
 import scalikejdbc.{AutoSession, DBSession}
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
 trait QiitaUserRepository {
   def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit
 }

--- a/app/domain/qiita/userranking/QiitaUserRankingRepository.scala
+++ b/app/domain/qiita/userranking/QiitaUserRankingRepository.scala
@@ -2,6 +2,7 @@ package domain.qiita.userranking
 
 import scalikejdbc.{AutoSession, DBSession}
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
 trait QiitaUserRankingRepository {
   def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit
 }

--- a/app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
+++ b/app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
@@ -3,6 +3,7 @@ package infrastructure.qiita
 import domain.qiita.{Initial, Page, QiitaUserInitial, QiitaUserInitialRepository}
 import scalikejdbc._
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
 final class ScalikejdbcQiitaUserInitialRepository extends QiitaUserInitialRepository {
   override def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit = {
     val initial = qiitaUserInitial.initial.value.toString

--- a/app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
+++ b/app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
@@ -3,7 +3,7 @@ package infrastructure.qiita
 import domain.qiita.{Initial, Page, QiitaUserInitial, QiitaUserInitialRepository}
 import scalikejdbc._
 
-@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments", "org.wartremover.warts.Nothing"))
 final class ScalikejdbcQiitaUserInitialRepository extends QiitaUserInitialRepository {
   override def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit = {
     val initial = qiitaUserInitial.initial.value.toString

--- a/app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
+++ b/app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
@@ -2,8 +2,7 @@ package infrastructure.qiita.user
 
 import domain.qiita.user.{QiitaUser, QiitaUserRepository}
 import scalikejdbc._
-
-@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments", "org.wartremover.warts.Nothing"))
 final class ScalikejdbcQiitaUserRepository extends QiitaUserRepository {
   override def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit = {
     val userName = qiitaUser.name.value

--- a/app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
+++ b/app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
@@ -3,6 +3,7 @@ package infrastructure.qiita.user
 import domain.qiita.user.{QiitaUser, QiitaUserRepository}
 import scalikejdbc._
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
 final class ScalikejdbcQiitaUserRepository extends QiitaUserRepository {
   override def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit = {
     val userName = qiitaUser.name.value

--- a/app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
+++ b/app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
@@ -3,6 +3,7 @@ package infrastructure.qiita.userranking
 import domain.qiita.userranking.{QiitaUserRanking, QiitaUserRankingRepository}
 import scalikejdbc._
 
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
 final class ScalikejdbcQiitaUserRankingRepository extends QiitaUserRankingRepository {
   override def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit = {
     val userName     = qiitaUserRanking.name.value

--- a/app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
+++ b/app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
@@ -3,7 +3,7 @@ package infrastructure.qiita.userranking
 import domain.qiita.userranking.{QiitaUserRanking, QiitaUserRankingRepository}
 import scalikejdbc._
 
-@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments"))
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments", "org.wartremover.warts.Nothing"))
 final class ScalikejdbcQiitaUserRankingRepository extends QiitaUserRankingRepository {
   override def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit = {
     val userName     = qiitaUserRanking.name.value


### PR DESCRIPTION
## Before

```
[warn]  [E1] app/Module.scala
[warn]       discarded non-Unit value
[warn]       L22:    configureInfrastructure()
[warn]       L22:                           ^
[warn]  [E2] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]       discarded non-Unit value
[warn]       L11:    sql"INSERT INTO qiita_user_initials (initial, page) VALUES ($initial, $page);".update.apply()
[warn]       L11:                                                                                               ^
[warn]  [E3] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
[warn]       discarded non-Unit value
[warn]       L9:    sql"INSERT INTO qiita_users (user_name) VALUES ($userName);".update.apply()
[warn]       L9:                                                                             ^
[warn]  [E4] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
[warn]       discarded non-Unit value
[warn]       L10:    sql"INSERT INTO qiita_user_rankings (user_name, contribution) VALUES ($userName, $contribution);".update.apply()
[warn]       L10:                                                                                                                  ^
[warn]  [E5] conf/routes
[warn]       Unused import
[warn]  [E6] conf/routes
[warn]       Unused import
[warn]  [E7] app/domain/qiita/QiitaUserInitialRepository.scala
[warn]       [wartremover:DefaultArguments] Function has default arguments
[warn]       L6:  def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit
[warn]       L6:                                                            ^
[warn]  [E8] app/domain/qiita/QiitaUserInitialRepository.scala
[warn]       [wartremover:DefaultArguments] Function has default arguments
[warn]       L8:  def retrieveAll()(implicit session: DBSession = AutoSession): Seq[QiitaUserInitial]
[warn]       L8:                             ^
[warn]  [E9] app/domain/qiita/QiitaUserInitialRepository.scala
[warn]       [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]       L6:  def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit
[warn]       L6:      ^
[warn]  [E10] app/domain/qiita/QiitaUserInitialRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L8:  def retrieveAll()(implicit session: DBSession = AutoSession): Seq[QiitaUserInitial]
[warn]        L8:      ^
[warn]  [E11] app/domain/qiita/user/QiitaUserRepository.scala
[warn]        [wartremover:DefaultArguments] Function has default arguments
[warn]        L6:  def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit
[warn]        L6:                                              ^
[warn]  [E12] app/domain/qiita/user/QiitaUserRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L6:  def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit
[warn]        L6:      ^
[warn]  [E13] app/domain/qiita/userranking/QiitaUserRankingRepository.scala
[warn]        [wartremover:DefaultArguments] Function has default arguments
[warn]        L6:  def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit
[warn]        L6:                                                            ^
[warn]  [E14] app/domain/qiita/userranking/QiitaUserRankingRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L6:  def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit
[warn]        L6:      ^
[warn]  [E15] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]        [wartremover:DefaultArguments] Function has default arguments
[warn]        L7:  override def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit = {
[warn]        L7:                                                                     ^
[warn]  [E16] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]        [wartremover:DefaultArguments] Function has default arguments
[warn]        L14:  override def retrieveAll()(implicit session: DBSession = AutoSession): Seq[QiitaUserInitial] = {
[warn]        L14:                                      ^
[warn]  [E17] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L7:  override def register(qiitaUserInitial: QiitaUserInitial)(implicit session: DBSession = AutoSession): Unit = {
[warn]        L7:               ^
[warn]  [E18] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L14:  override def retrieveAll()(implicit session: DBSession = AutoSession): Seq[QiitaUserInitial] = {
[warn]        L14:               ^
[warn]  [E19] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]        [wartremover:Nothing] Inferred type containing Nothing
[warn]        L11:    sql"INSERT INTO qiita_user_initials (initial, page) VALUES ($initial, $page);".update.apply()
[warn]        L11:    ^
[warn]  [E20] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]        [wartremover:Nothing] Inferred type containing Nothing
[warn]        L15:    sql"SELECT * FROM qiita_user_initials ORDER BY id ASC;".map { rs =>
[warn]        L15:    ^
[warn]  [E21] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
[warn]        [wartremover:DefaultArguments] Function has default arguments
[warn]        L7:  override def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit = {
[warn]        L7:                                                       ^
[warn]  [E22] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L7:  override def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit = {
[warn]        L7:               ^
[warn]  [E23] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
[warn]        [wartremover:Nothing] Inferred type containing Nothing
[warn]        L9:    sql"INSERT INTO qiita_users (user_name) VALUES ($userName);".update.apply()
[warn]        L9:    ^
[warn]  [E24] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
[warn]        [wartremover:DefaultArguments] Function has default arguments
[warn]        L7:  override def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit = {
[warn]        L7:                                                                     ^
[warn]  [E25] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
[warn]        [wartremover:ImplicitParameter] Implicit parameters are disabled
[warn]        L7:  override def register(qiitaUserRanking: QiitaUserRanking)(implicit session: DBSession = AutoSession): Unit = {
[warn]        L7:               ^
[warn]  [E26] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
[warn]        [wartremover:Nothing] Inferred type containing Nothing
[warn]        L10:    sql"INSERT INTO qiita_user_rankings (user_name, contribution) VALUES ($userName, $contribution);".update.apply()
[warn]        L10:    ^
[warn] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala: L7 [E24], L7 [E25], L10 [E4], L10 [E26]
[warn] app/Module.scala: L22 [E1]
[warn] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala: L7 [E21], L7 [E22], L9 [E3], L9 [E23]
[warn] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala: L7 [E15], L7 [E17], L11 [E2], L11 [E19], L14 [E16], L14 [E18], L15 [E20]
[warn] app/domain/qiita/user/QiitaUserRepository.scala: L6 [E11], L6 [E12]
[warn] app/domain/qiita/QiitaUserInitialRepository.scala: L6 [E7], L6 [E9], L8 [E8], L8 [E10]
[warn] app/domain/qiita/userranking/QiitaUserRankingRepository.scala: L6 [E13], L6 [E14]
[info] Legend: Ln = line n, Cn = column n, En = error n
```

## After

```
[warn]  [E1] app/Module.scala
[warn]       discarded non-Unit value
[warn]       L22:    configureInfrastructure()
[warn]       L22:                           ^
[warn]  [E2] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]       discarded non-Unit value
[warn]       L13:    sql"INSERT INTO qiita_user_initials (initial, page) VALUES ($initial, $page);".update.apply()
[warn]       L13:                                                                                               ^
[warn]  [E3] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
[warn]       discarded non-Unit value
[warn]       L10:    sql"INSERT INTO qiita_users (user_name) VALUES ($userName);".update.apply()
[warn]       L10:                                                                             ^
[warn]  [E4] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
[warn]       discarded non-Unit value
[warn]       L12:    sql"INSERT INTO qiita_user_rankings (user_name, contribution) VALUES ($userName, $contribution);".update.apply()
[warn]       L12:                                                                                                                  ^
[warn]  [E5] conf/routes
[warn]       Unused import
[warn]  [E6] conf/routes
[warn]       Unused import
[warn] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala: L12 [E4]
[warn] app/Module.scala: L22 [E1]
[warn] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala: L10 [E3]
[warn] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala: L13 [E2]
[info] Legend: Ln = line n, Cn = column n, En = error n
```