### PR TITLE
Repositoryの「discarded non-Unit value」警告を駆逐

### DIFF
--- a/app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
+++ b/app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
@@ -10,6 +10,8 @@ final class ScalikejdbcQiitaUserInitialRepository extends QiitaUserInitialReposi
     val page    = qiitaUserInitial.page.value
 
     sql"INSERT INTO qiita_user_initials (initial, page) VALUES ($initial, $page);".update.apply()
+
+    () // 明示的に Unit を返す
   }
 
   override def retrieveAll()(implicit session: DBSession = AutoSession): Seq[QiitaUserInitial] = {

--- a/app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
+++ b/app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
@@ -2,10 +2,13 @@ package infrastructure.qiita.user
 
 import domain.qiita.user.{QiitaUser, QiitaUserRepository}
 import scalikejdbc._
+
 @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter", "org.wartremover.warts.DefaultArguments", "org.wartremover.warts.Nothing"))
 final class ScalikejdbcQiitaUserRepository extends QiitaUserRepository {
   override def register(qiitaUser: QiitaUser)(implicit session: DBSession = AutoSession): Unit = {
     val userName = qiitaUser.name.value
     sql"INSERT INTO qiita_users (user_name) VALUES ($userName);".update.apply()
+
+    () // 明示的に Unit を返す
   }
 }

--- a/app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
+++ b/app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
@@ -9,5 +9,7 @@ final class ScalikejdbcQiitaUserRankingRepository extends QiitaUserRankingReposi
     val userName     = qiitaUserRanking.name.value
     val contribution = qiitaUserRanking.contribution.value
     sql"INSERT INTO qiita_user_rankings (user_name, contribution) VALUES ($userName, $contribution);".update.apply()
+
+    () // 明示的に Unit を返す
   }
 }


### PR DESCRIPTION
## Before

```
[warn]  [E1] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala
[warn]       discarded non-Unit value
[warn]       L15:    sql"INSERT INTO qiita_user_initials (initial, page) VALUES ($initial, $page);".update.apply()
[warn]       L15:                                                                                               ^
[warn]  [E2] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala
[warn]       discarded non-Unit value
[warn]       L12:    sql"INSERT INTO qiita_users (user_name) VALUES ($userName);".update.apply()
[warn]       L12:                                                                             ^
[warn]  [E3] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala
[warn]       discarded non-Unit value
[warn]       L14:    sql"INSERT INTO qiita_user_rankings (user_name, contribution) VALUES ($userName, $contribution);".update.apply()
[warn]       L14:                                                                                                                  ^
[warn]  [E4] conf/routes
[warn]       Unused import
[warn]  [E5] conf/routes
[warn]       Unused import
[warn] app/infrastructure/qiita/userranking/ScalikejdbcQiitaUserRankingRepository.scala: L14 [E3]
[warn] app/infrastructure/qiita/user/ScalikejdbcQiitaUserRepository.scala: L12 [E2]
[warn] app/infrastructure/qiita/ScalikejdbcQiitaUserInitialRepository.scala: L15 [E1]
[info] Legend: Ln = line n, Cn = column n, En = error n
```


## After

```
[warn]  [E1] conf/routes
[warn]       Unused import
[warn]  [E2] conf/routes
[warn]       Unused import
[info] Legend: Ln = line n, Cn = column n, En = error n
```