### PR TITLE
コンパイルオプションからunused-importの警告を除外

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -37,6 +37,8 @@ object BuildSettings {
       * -Ywarn-unused で imports と patvars を除外している理由は routes が警告を出すためである。
       * 本当は有効にしたいのだが routes だけ除外するという設定ができなかったため、泣く泣くコメントアウトした。
       *
+      * -Ywarn-unused-import をコメントアウトしている理由も -Ywarn-unused 同様である。
+      *
       * -Xfatal-warning であるが、有効にするとなぜか共通ライブラリがエラーになる(警告ないのに。。)のでコメントアウトしている。
       * 共通ライブラリを別リポジトリに切り出したら、有効にしても良いかもしれない。
       *
@@ -49,8 +51,8 @@ object BuildSettings {
       "-Xlint", // Enable or disable specific warnings: `_' for all, `-Xlint:help' to list choices.
       "-Ywarn-dead-code", // Warn when dead code is identified.
       "-Ywarn-numeric-widen", // Warn when numerics are widened.
-      "-Ywarn-unused:-patvars,_", // Warn when local and private vals, vars, defs, and types are unused.
-      "-Ywarn-unused-import", // Warn when imports are unused.
+      "-Ywarn-unused:-patvars,-imports,_", // Warn when local and private vals, vars, defs, and types are unused.
+      // "-Ywarn-unused-import", // Warn when imports are unused.
       "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
       //, "-Xfatal-warning" // 警告があった場合、コンパイルエラーにする
     ),


### PR DESCRIPTION
## Before

```
[warn]  [E1] conf/routes
[warn]       Unused import
[warn]  [E2] conf/routes
[warn]       Unused import
[info] Legend: Ln = line n, Cn = column n, En = error n
```


## After

```
```